### PR TITLE
Add China Element Plus theme

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -31,6 +31,8 @@ declare module 'vue' {
     ElMenuItem: typeof import('element-plus/es')['ElMenuItem']
     ElScrollbar: typeof import('element-plus/es')['ElScrollbar']
     ElSubMenu: typeof import('element-plus/es')['ElSubMenu']
+    ElSwitch: typeof import('element-plus/es')['ElSwitch']
+    ElTooltip: typeof import('element-plus/es')['ElTooltip']
     HelloWorld: typeof import('./components/HelloWorld.vue')['default']
     IconAntDesignGithubOutlined: typeof import('~icons/ant-design/github-outlined')['default']
     IconAntDesignLockOutlined: typeof import('~icons/ant-design/lock-outlined')['default']

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,22 +1,110 @@
-export const config = Object.freeze({
+import type {AppTheme} from './types'
+
+type ThemeConfig = {
+  label: string
   aside: {
-    logo: 'https://element-plus.gitee.io/images/element-plus-logo-small.svg',
-    title: 'Element Plus Admin',
-    width: '240px',
-    bgColor: '#001428',
-  },
+    logo: string
+    mark: string
+    title: string
+    width: string
+    bgColor: string
+    markBgColor: string
+    markColor: string
+  }
   drawer: {
-    padding: '0px',
-    width: '200px',
-    bgColor: '#001428',
-  },
+    padding: string
+    width: string
+    bgColor: string
+  }
   menu: {
-    textColor: '#bbb',
-    hoverTextColor: '#fff',
-    activeTextColor: '#fff',
-    bgColor: '#001428',
-    hoverBgColor: 'transparent',
-    activeBgColor: '#2d8cf0',
-    borderColor: 'transparent',
+    textColor: string
+    hoverTextColor: string
+    activeTextColor: string
+    bgColor: string
+    hoverBgColor: string
+    activeBgColor: string
+    borderColor: string
+  }
+  layout: {
+    bgColor: string
+    headerBgColor: string
+    headerBorderColor: string
+  }
+}
+
+export const defaultTheme: AppTheme = 'default'
+
+export const themeConfigs = {
+  default: {
+    label: '默认',
+    aside: {
+      logo: 'https://element-plus.gitee.io/images/element-plus-logo-small.svg',
+      mark: 'EP',
+      title: 'Element Plus Admin',
+      width: '240px',
+      bgColor: '#001428',
+      markBgColor: '#ffffff',
+      markColor: '#2d8cf0',
+    },
+    drawer: {
+      padding: '0px',
+      width: '200px',
+      bgColor: '#001428',
+    },
+    menu: {
+      textColor: '#bbb',
+      hoverTextColor: '#fff',
+      activeTextColor: '#fff',
+      bgColor: '#001428',
+      hoverBgColor: 'transparent',
+      activeBgColor: '#2d8cf0',
+      borderColor: 'transparent',
+    },
+    layout: {
+      bgColor: '#f5f7f9',
+      headerBgColor: '#fff',
+      headerBorderColor: 'transparent',
+    },
   },
-})
+  china: {
+    label: '中国',
+    aside: {
+      logo: '',
+      mark: '中',
+      title: '华夏后台',
+      width: '240px',
+      bgColor: 'linear-gradient(180deg, #8f1622 0%, #5f1018 100%)',
+      markBgColor: '#f4cf77',
+      markColor: '#7b1119',
+    },
+    drawer: {
+      padding: '0px',
+      width: '220px',
+      bgColor: 'linear-gradient(180deg, #8f1622 0%, #5f1018 100%)',
+    },
+    menu: {
+      textColor: '#f7d7a2',
+      hoverTextColor: '#fff8e7',
+      activeTextColor: '#fff8e7',
+      bgColor: 'transparent',
+      hoverBgColor: 'rgba(244, 207, 119, 0.12)',
+      activeBgColor: '#c52b35',
+      borderColor: 'transparent',
+    },
+    layout: {
+      bgColor: '#f8f1e8',
+      headerBgColor: '#fffaf1',
+      headerBorderColor: 'rgba(143, 22, 34, 0.16)',
+    },
+  },
+} as const satisfies Record<AppTheme, ThemeConfig>
+
+export const themeOptions = Object.freeze(
+  Object.entries(themeConfigs).map(([value, theme]) => ({
+    label: theme.label,
+    value: value as AppTheme,
+  })),
+)
+
+export const getThemeConfig = (theme: AppTheme) => themeConfigs[theme]
+export const config = themeConfigs[defaultTheme]

--- a/src/layouts/components/AsideLogo.vue
+++ b/src/layouts/components/AsideLogo.vue
@@ -1,20 +1,71 @@
 <script lang="ts" setup>
-import {config} from '~/config'
+import {getThemeConfig} from '~/config'
 
 defineProps({
   collapsed: Boolean,
 })
+
+const appStore = useAppStore()
+const {theme} = storeToRefs(appStore)
+const config = computed(() => getThemeConfig(theme.value))
 </script>
 
 <template>
-  <div h="64px" flex justify="center" items="center" text="white">
+  <div
+    class="aside-logo"
+    h="64px"
+    flex
+    justify="center"
+    items="center"
+    text="white"
+  >
     <img
+      v-if="config.aside.logo"
       :src="config.aside.logo"
       alt="Aside Logo"
       :class="{'mr-2': !collapsed}"
       w="auto"
       h="32px"
     />
+    <span
+      v-else
+      class="aside-logo__mark"
+      :class="{'mr-2': !collapsed}"
+      :style="{
+        background: config.aside.markBgColor,
+        color: config.aside.markColor,
+      }"
+    >
+      {{ config.aside.mark }}
+    </span>
     <h1 v-show="!collapsed" class="title">{{ config.aside.title }}</h1>
   </div>
 </template>
+
+<style scoped>
+.aside-logo {
+  overflow: hidden;
+}
+
+.aside-logo__mark {
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 0.42),
+    0 8px 18px rgb(0 0 0 / 0.16);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 32px;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+</style>

--- a/src/layouts/components/AsideMenu.vue
+++ b/src/layouts/components/AsideMenu.vue
@@ -1,22 +1,19 @@
 <script lang="ts" setup>
 import type {RouteRecordRaw} from 'vue-router'
-import {config} from '~/config'
+import {getThemeConfig} from '~/config'
 import {MENUS} from '~/constants'
 
-const props = defineProps({
+defineProps({
   collapsed: Boolean,
 })
 defineEmits(['update:collapsed'])
 
 const menus = ref<RouteRecordRaw[]>(MENUS)
-
-watch(
-  () => props.collapsed,
-  () => {
-    // TODO:
-    console.log(props.collapsed)
-  },
-)
+const appStore = useAppStore()
+const {theme} = storeToRefs(appStore)
+const config = computed(() => getThemeConfig(theme.value))
+const hoverTextColor = computed(() => config.value.menu.hoverTextColor)
+const activeBgColor = computed(() => config.value.menu.activeBgColor)
 </script>
 
 <template>
@@ -27,7 +24,7 @@ watch(
       '--el-menu-active-color': config.menu.activeTextColor,
       '--el-menu-bg-color': config.menu.bgColor,
       '--el-menu-hover-bg-color': config.menu.hoverBgColor,
-      '--el-menu-acitve-bg-color': config.menu.activeBgColor,
+      '--el-menu-active-bg-color': config.menu.activeBgColor,
       '--el-menu-border-color': config.menu.borderColor,
     }"
     :default-active="$route.path"
@@ -41,9 +38,9 @@ watch(
 /* Some colors are not exposed via css variable */
 :deep(.el-sub-menu__title:hover),
 :deep(.el-menu-item:hover) {
-  color: v-bind('config.menu.hoverTextColor');
+  color: v-bind('hoverTextColor');
 }
 :deep(.el-menu-item.is-active) {
-  background-color: v-bind('config.menu.activeBgColor');
+  background-color: v-bind('activeBgColor');
 }
 </style>

--- a/src/layouts/components/Navbar.vue
+++ b/src/layouts/components/Navbar.vue
@@ -3,6 +3,16 @@ defineProps({
   collapsed: Boolean,
 })
 defineEmits(['update:collapsed'])
+
+const appStore = useAppStore()
+const {theme} = storeToRefs(appStore)
+const isChinaTheme = computed({
+  get: () => theme.value === 'china',
+  set: value => appStore.setTheme(value ? 'china' : 'default'),
+})
+const themeTip = computed(() =>
+  isChinaTheme.value ? '切换为默认主题' : '切换为中国主题',
+)
 </script>
 
 <template>
@@ -29,6 +39,18 @@ defineEmits(['update:collapsed'])
       </el-breadcrumb>
     </div>
     <div class="h-full flex">
+      <div class="h-full px-4 flex items-center">
+        <el-tooltip :content="themeTip" placement="bottom">
+          <el-switch
+            v-model="isChinaTheme"
+            class="theme-switch"
+            inline-prompt
+            active-text="中"
+            inactive-text="默"
+            :aria-label="themeTip"
+          />
+        </el-tooltip>
+      </div>
       <div class="h-full px-4 cursor-pointer flex items-center">
         <el-icon size="18" class="h-full">
           <icon-ant-design-SearchOutlined />
@@ -60,3 +82,10 @@ defineEmits(['update:collapsed'])
     </div>
   </div>
 </template>
+
+<style scoped>
+.theme-switch {
+  --el-switch-on-color: #bf1e2e;
+  --el-switch-off-color: #2d8cf0;
+}
+</style>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -1,11 +1,14 @@
 <script lang="ts" setup>
-import {config} from '~/config'
+import {getThemeConfig} from '~/config'
 
 setupWindowResize()
 
 const appStore = useAppStore()
 const {asideToggle, drawerCollapse, drawerToggle} = appStore
-const {device, asideCollapsed, drawerDisplay} = storeToRefs(appStore)
+const {device, asideCollapsed, drawerDisplay, theme} = storeToRefs(appStore)
+const config = computed(() => getThemeConfig(theme.value))
+const drawerBgColor = computed(() => config.value.drawer.bgColor)
+const drawerPadding = computed(() => config.value.drawer.padding)
 
 function onToggleMenuCollapsed() {
   if (device.value === 'mobile') {
@@ -17,7 +20,7 @@ function onToggleMenuCollapsed() {
 </script>
 
 <template>
-  <el-container>
+  <el-container class="app-layout">
     <el-aside
       v-if="device != 'mobile'"
       translate="width-ease-200"
@@ -43,8 +46,18 @@ function onToggleMenuCollapsed() {
       </el-drawer>
     </div>
 
-    <el-container bg="#f5f7f9">
-      <el-header h="64px" bg="white">
+    <el-container
+      class="app-layout__body"
+      :style="{background: config.layout.bgColor}"
+    >
+      <el-header
+        class="app-layout__header"
+        h="64px"
+        :style="{
+          background: config.layout.headerBgColor,
+          borderColor: config.layout.headerBorderColor,
+        }"
+      >
         <Navbar @update:collapsed="onToggleMenuCollapsed" />
       </el-header>
       <el-main>
@@ -56,9 +69,18 @@ function onToggleMenuCollapsed() {
 </template>
 
 <style>
-/* TODO: */
+.app-layout,
+.app-layout__body {
+  min-height: 100vh;
+}
+
+.app-layout__header {
+  border-bottom: 1px solid transparent;
+  box-sizing: border-box;
+}
+
 .el-drawer {
-  --el-drawer-bg-color: v-bind('config.drawer.bgColor') !important;
-  --el-drawer-padding-primary: v-bind('config.drawer.padding') !important;
+  --el-drawer-bg-color: v-bind('drawerBgColor') !important;
+  --el-drawer-padding-primary: v-bind('drawerPadding') !important;
 }
 </style>

--- a/src/main.css
+++ b/src/main.css
@@ -6,8 +6,91 @@ body,
   padding: 0;
 }
 
+:root {
+  --admin-page-bg: #f5f7f9;
+}
+
 html.dark {
   background: #121212;
+}
+
+body {
+  background: var(--admin-page-bg);
+}
+
+html[data-theme='china'] {
+  --admin-page-bg: #f8f1e8;
+  --el-color-primary: #bf1e2e;
+  --el-color-primary-light-3: #d45c61;
+  --el-color-primary-light-5: #e19287;
+  --el-color-primary-light-7: #efc0ae;
+  --el-color-primary-light-8: #f6d8c7;
+  --el-color-primary-light-9: #fff2e2;
+  --el-color-primary-dark-2: #8f1622;
+  --el-color-success: #2f7d54;
+  --el-color-warning: #b97812;
+  --el-color-danger: #a7171f;
+  --el-color-info: #7a6757;
+  --el-bg-color: #fffaf1;
+  --el-bg-color-page: #f8f1e8;
+  --el-bg-color-overlay: #fffdf8;
+  --el-text-color-primary: #3a2021;
+  --el-text-color-regular: #5d3b34;
+  --el-text-color-secondary: #836357;
+  --el-text-color-placeholder: #b39783;
+  --el-border-color: #ead7ba;
+  --el-border-color-light: #f0dfc6;
+  --el-border-color-lighter: #f7ead6;
+  --el-border-color-extra-light: #fbf2e7;
+  --el-fill-color: #f7ead6;
+  --el-fill-color-light: #fbf1e3;
+  --el-fill-color-lighter: #fff6ea;
+  --el-fill-color-extra-light: #fffaf1;
+  --el-fill-color-blank: #fffdf8;
+  --el-border-radius-base: 2px;
+  --el-border-radius-small: 2px;
+  --el-main-padding: 24px;
+  --el-box-shadow-light: 0 12px 28px rgb(128 38 30 / 0.12);
+  background: var(--admin-page-bg);
+  color: var(--el-text-color-primary);
+}
+
+html[data-theme='china'] .el-button--primary {
+  --el-button-bg-color: var(--el-color-primary);
+  --el-button-border-color: var(--el-color-primary);
+  --el-button-hover-bg-color: #d83a3f;
+  --el-button-hover-border-color: #d83a3f;
+  --el-button-active-bg-color: var(--el-color-primary-dark-2);
+  --el-button-active-border-color: var(--el-color-primary-dark-2);
+}
+
+html[data-theme='china'] .el-input__wrapper,
+html[data-theme='china'] .el-textarea__inner,
+html[data-theme='china'] .el-select__wrapper {
+  background-color: #fffdf8;
+  box-shadow: 0 0 0 1px var(--el-border-color) inset;
+}
+
+html[data-theme='china'] .el-input__wrapper.is-focus,
+html[data-theme='china'] .el-textarea__inner:focus,
+html[data-theme='china'] .el-select__wrapper.is-focused {
+  box-shadow: 0 0 0 1px var(--el-color-primary) inset;
+}
+
+html[data-theme='china'] .el-menu {
+  border-right: 0;
+}
+
+html[data-theme='china'] .el-menu-item,
+html[data-theme='china'] .el-sub-menu__title {
+  height: 44px;
+  line-height: 44px;
+  margin: 4px 10px;
+  border-radius: 2px;
+}
+
+html[data-theme='china'] .el-menu-item.is-active {
+  box-shadow: inset 3px 0 0 #f4cf77, 0 8px 18px rgb(58 18 18 / 0.16);
 }
 
 #nprogress {
@@ -24,6 +107,6 @@ html.dark {
   height: 2px;
 }
 
-/* TODO: custom theme
---el-main-padding
-*/
+html[data-theme='china'] #nprogress .bar {
+  background: linear-gradient(90deg, #bf1e2e, #f4cf77);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ const app = createApp(App)
 
 // Setup routes
 const router = createRouter({
-  routes: setupLayouts(routes),
+  routes: setupLayouts([...routes]),
   history: createWebHistory(),
 })
 app.use(router)

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -1,8 +1,40 @@
 import Cookies from 'js-cookie'
 import {defineStore} from 'pinia'
-import type {AppDevice} from '../types'
+import {defaultTheme} from '../config'
+import type {AppDevice, AppTheme} from '../types'
+
+const APP_THEME = 'APP_THEME'
+
+function normalizeTheme(value: string | undefined): AppTheme {
+  return value === 'china' ? value : defaultTheme
+}
+
+function applyTheme(value: AppTheme) {
+  if (typeof document === 'undefined') return
+  document.documentElement.dataset.theme = value
+}
 
 export const useAppStore = defineStore('app', () => {
+  const theme = ref<AppTheme>(normalizeTheme(Cookies.get(APP_THEME)))
+  watch(
+    theme,
+    value => {
+      if (value === defaultTheme) {
+        Cookies.remove(APP_THEME)
+      } else {
+        Cookies.set(APP_THEME, value)
+      }
+      applyTheme(value)
+    },
+    {immediate: true},
+  )
+  function setTheme(value: AppTheme) {
+    theme.value = normalizeTheme(value)
+  }
+  function themeToggle() {
+    setTheme(theme.value === 'china' ? defaultTheme : 'china')
+  }
+
   const device = ref<AppDevice>('desktop')
   function setDevice(value: AppDevice) {
     device.value = value
@@ -31,6 +63,9 @@ export const useAppStore = defineStore('app', () => {
   }
 
   return {
+    theme,
+    setTheme,
+    themeToggle,
     device,
     asideCollapsed,
     asideCollapse,

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,8 +4,9 @@ import type {Router, RouteRecordRaw} from 'vue-router'
 export type UserModule = (ctx: {
   app: App<Element>
   router: Router
-  routes: RouteRecordRaw[]
+  routes: readonly RouteRecordRaw[]
   isClient: boolean
 }) => void
 
 export type AppDevice = 'desktop' | 'tablet' | 'mobile'
+export type AppTheme = 'default' | 'china'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "module": "ESNext",
     "target": "ESNext",
     "lib": ["DOM", "ESNext"],


### PR DESCRIPTION
Summary:
- Add a runtime China theme driven by Element Plus CSS variables.
- Add a navbar theme switch and themed layout/menu/logo styles.
- Keep TypeScript build compatible with readonly generated routes.

Verification:
- CHOKIDAR_USEPOLLING=1 pnpm build